### PR TITLE
feat: add abstract store and seed methods for factories

### DIFF
--- a/.changeset/fast-ghosts-fold.md
+++ b/.changeset/fast-ghosts-fold.md
@@ -1,0 +1,5 @@
+---
+"test-data-factory": minor
+---
+
+Added an abstract `AbstractStore` class as a contract between factories and stores.

--- a/.changeset/mean-crabs-like.md
+++ b/.changeset/mean-crabs-like.md
@@ -1,0 +1,5 @@
+---
+"test-data-factory": minor
+---
+
+Added `seed()` and `seedMany()` methods to factories, which insert built test-data into a given store. They accept any store that extends the `AbstractStore` class.

--- a/src/abstract-store.ts
+++ b/src/abstract-store.ts
@@ -1,0 +1,13 @@
+/** A minimal interface that must be implemented by a store to interface with factories. */
+export abstract class AbstractStore {
+  /**
+   * Inserts an entry from the given factory identifier into the store.
+   * This function can optionally be asynchronous.
+   *
+   * @returns `true` if the entry was successfully inserted, `false` otherwise.
+   */
+  protected abstract insert<Shape>(
+    identifier: symbol,
+    entry: Shape,
+  ): boolean | Promise<boolean>;
+}

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -304,8 +304,12 @@ suite("Factory.prototype.seedMany", () => {
     const store = new Store();
     const factory = TestFactory.create();
 
-    await factory.seedMany(store, 2);
+    const data = await factory.seedMany(store, 2);
 
+    expect(data).toStrictEqual([
+      { a: 0, b: 0 },
+      { a: 0, b: 0 },
+    ]);
     expect(store["insert"]).toHaveBeenCalledTimes(2);
     expect(store["insert"]).toHaveBeenNthCalledWith(1, factory.identifier, {
       a: 0,

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -293,6 +293,18 @@ suite("Factory.prototype.seed", () => {
       b: 0,
     });
   });
+
+  test("throws an error when 'insert' returns false", async () => {
+    const store = new Store();
+    const factory = TestFactory.create();
+    store["insert"].mockReturnValue(false);
+
+    const call = () => factory.seed(store);
+
+    await expect(call).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: Failed to insert data into store for factory "TestFactory". Does the store know this factory?]`,
+    );
+  });
 });
 
 suite("Factory.prototype.seedMany", () => {
@@ -319,6 +331,18 @@ suite("Factory.prototype.seedMany", () => {
       a: 0,
       b: 0,
     });
+  });
+
+  test("throws an error when 'insert' returns false", async () => {
+    const store = new Store();
+    const factory = TestFactory.create();
+    store["insert"].mockReturnValue(false);
+
+    const call = () => factory.seed(store);
+
+    await expect(call).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: Failed to insert data into store for factory "TestFactory". Does the store know this factory?]`,
+    );
   });
 
   test("passes provided amount and params to buildMany", async () => {


### PR DESCRIPTION
Adds an `AbstractStore` class with is a reference for an interface that store implementations have to implement to be able to interface with factories.

Further, this PR adds `Factory.prototype.seed` and `Factory.prototype.seedMany` methods for seeding data into a given store. The seeded data is additionally returned.