### PR TITLE
chore: make modules compatible with type-stripping

### DIFF
--- a/exports/main.ts
+++ b/exports/main.ts
@@ -1,4 +1,4 @@
-export { defineFactory, type ConstructFn } from "../src/factory-shorthand.js";
-export { Factory, type FactoryContext } from "../src/factory.js";
-export type { Params } from "../src/params.js";
-export { Store } from "../src/store.js";
+export { defineFactory, type ConstructFn } from "../src/factory-shorthand.ts";
+export { Factory, type FactoryContext } from "../src/factory.ts";
+export type { Params } from "../src/params.ts";
+export { Store } from "../src/store.ts";

--- a/src/factory-shorthand.test.ts
+++ b/src/factory-shorthand.test.ts
@@ -1,6 +1,6 @@
 import { expect, suite, test, vi } from "vitest";
-import { defineFactory } from "./factory-shorthand.js";
-import { Factory } from "./factory.js";
+import { defineFactory } from "./factory-shorthand.ts";
+import { Factory } from "./factory.ts";
 
 suite(defineFactory, () => {
   test("returns a new factory instance", () => {

--- a/src/factory-shorthand.ts
+++ b/src/factory-shorthand.ts
@@ -1,4 +1,4 @@
-import { Factory, type Context } from "./factory.js";
+import { Factory, type Context } from "./factory.ts";
 
 export interface ConstructFn<Shape, F extends Factory<Shape>> {
   (ctx: Context<F>): Shape;

--- a/src/factory.test.ts
+++ b/src/factory.test.ts
@@ -1,6 +1,6 @@
 import { expect, suite, test, vi } from "vitest";
-import { AbstractStore } from "./abstract-store.js";
-import { Factory, type FactoryContext } from "./factory.js";
+import { AbstractStore } from "./abstract-store.ts";
+import { Factory, type FactoryContext } from "./factory.ts";
 
 class TestFactory extends Factory<{ a: number; b: number }> {
   protected override construct() {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,11 +1,11 @@
-import type { AbstractStore } from "./abstract-store.js";
+import type { AbstractStore } from "./abstract-store.ts";
 import {
   applyParams,
   combineParams,
   evalParamsOrFunc,
   type Params,
   type ParamsOrFunc,
-} from "./params.js";
+} from "./params.ts";
 
 type ShapeFor<F> = F extends Factory<infer S> ? S : never;
 interface FactoryClass<Factory, Shape> {

--- a/src/params.test.ts
+++ b/src/params.test.ts
@@ -1,5 +1,5 @@
 import { expect, suite, test, vi } from "vitest";
-import { applyParams, combineParams, evalParamsOrFunc } from "./params.js";
+import { applyParams, combineParams, evalParamsOrFunc } from "./params.ts";
 
 suite.for([applyParams, combineParams])("%o shared", (paramsFn) => {
   test("returns the given entry when no params are provided", () => {

--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -1,6 +1,6 @@
 import { expect, suite, test, vi } from "vitest";
-import * as params from "./params.js";
-import { applyUpdateQuery, assertStrict } from "./query.js";
+import * as params from "./params.ts";
+import { applyUpdateQuery, assertStrict } from "./query.ts";
 
 suite("assertStrict", () => {
   const where = () => true;

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,4 +1,4 @@
-import { applyParams, type Params } from "./params.js";
+import { applyParams, type Params } from "./params.ts";
 
 export interface Query<Shape> {
   where(entry: Shape): boolean;

--- a/src/store-collection.test.ts
+++ b/src/store-collection.test.ts
@@ -1,5 +1,5 @@
 import { expect, suite, test } from "vitest";
-import { StoreCollection } from "./store-collection.js";
+import { StoreCollection } from "./store-collection.ts";
 
 interface Data {
   a: number;

--- a/src/store-collection.ts
+++ b/src/store-collection.ts
@@ -4,7 +4,7 @@ import {
   type Query,
   type StrictQuery,
   type UpdateQuery,
-} from "./query.js";
+} from "./query.ts";
 
 export class StoreCollection<Shape> {
   #entries: Shape[];

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,8 +1,8 @@
 import { expect, suite, test, vi } from "vitest";
-import { AbstractStore } from "./abstract-store.js";
-import { defineFactory } from "./factory-shorthand.js";
-import { StoreCollection } from "./store-collection.js";
-import { Store } from "./store.js";
+import { AbstractStore } from "./abstract-store.ts";
+import { defineFactory } from "./factory-shorthand.ts";
+import { StoreCollection } from "./store-collection.ts";
+import { Store } from "./store.ts";
 
 suite("Store.create", () => {
   test("creates a new instance of the implementing store class", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
-import { AbstractStore } from "./abstract-store.js";
-import type { Factory } from "./factory.js";
-import { StoreCollection } from "./store-collection.js";
+import { AbstractStore } from "./abstract-store.ts";
+import type { Factory } from "./factory.ts";
+import { StoreCollection } from "./store-collection.ts";
 
 interface StoreClass<Store> {
   new (): Store;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
 
     /* Type Checking */
     "strict": true,


### PR DESCRIPTION
This PR switches all modules to import from `.ts` path specifiers which makes them compatible with Deno (possibly) and Node.js type-stripping. During the build step, the paths are rewritten for publishing