### PR TITLE
feat(store): add query and update methods to collections

### DIFF
--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -1,0 +1,31 @@
+import { expect, suite, test } from "vitest";
+import { assertStrict } from "./query.js";
+
+suite("assertStrict", () => {
+  const where = () => true;
+
+  test("returns null when no entry is provided and strict is false", () => {
+    expect(assertStrict({ where, strict: false })).toBe(null);
+    expect(assertStrict({ where, strict: false }, undefined)).toBe(null);
+  });
+
+  test("returns the entry when it is provided", () => {
+    const entry = { a: 0 };
+
+    expect(assertStrict({ where }, entry)).toBe(entry);
+    expect(assertStrict({ where, strict: false }, entry)).toBe(entry);
+    expect(assertStrict({ where, strict: true }, entry)).toBe(entry);
+  });
+
+  test("throws an error when no entry is provided and strict is true", () => {
+    const implicit = () => assertStrict({ where });
+    const explicit = () => assertStrict({ where, strict: true });
+
+    expect(implicit).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: No entry found in the collection for the given strict query.]`,
+    );
+    expect(explicit).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: No entry found in the collection for the given strict query.]`,
+    );
+  });
+});

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,25 @@
+export interface Query<Shape> {
+  where(entry: Shape): boolean;
+}
+
+export interface StrictQuery<Shape, Strict extends boolean = true>
+  extends Query<Shape> {
+  /** @default true */
+  strict?: Strict;
+}
+
+export function assertStrict<Shape>(
+  query: StrictQuery<Shape, boolean>,
+  entry?: Shape,
+): Shape | null {
+  if (entry) return entry;
+
+  // strict mode is the default
+  if (query.strict !== false) {
+    throw new TypeError(
+      "No entry found in the collection for the given strict query.",
+    );
+  }
+
+  return null;
+}

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,3 +1,5 @@
+import { applyParams, type Params } from "./params.js";
+
 export interface Query<Shape> {
   where(entry: Shape): boolean;
 }
@@ -22,4 +24,21 @@ export function assertStrict<Shape>(
   }
 
   return null;
+}
+
+type DataOrUpdateFn<Shape> = Params<Shape> | ((entry: Shape) => Params<Shape>);
+
+export interface UpdateQuery<Shape, Strict extends boolean = true>
+  extends StrictQuery<Shape, Strict> {
+  data: DataOrUpdateFn<Shape>;
+}
+
+export function applyUpdateQuery<Shape>(
+  entry: Shape,
+  query: UpdateQuery<Shape, boolean>,
+): Shape {
+  const update =
+    typeof query.data === "function" ? query.data(entry) : query.data;
+
+  return applyParams(entry, update);
 }

--- a/src/store-collection.test.ts
+++ b/src/store-collection.test.ts
@@ -155,3 +155,91 @@ suite("StoreCollection.prototype.findMany", () => {
     expect(entries).toStrictEqual([]);
   });
 });
+
+suite("StoreCollection.prototype.update", () => {
+  test("updates the first entry that matches the query", () => {
+    const collection = new StoreCollection<Data>();
+    collection.insert({ a: 1, b: 0 });
+    collection.insert({ a: 1, b: 1 });
+    collection.insert({ a: 0, b: 1 });
+
+    const updated = collection.update({
+      where: (e) => e.b === 1,
+      data: { a: 2 },
+    });
+
+    expect(updated).toStrictEqual({ a: 2, b: 1 });
+    expect(collection.all()).toStrictEqual([
+      { a: 1, b: 0 },
+      { a: 2, b: 1 },
+      { a: 0, b: 1 },
+    ]);
+  });
+
+  test("throws an error when no entry matches the given query", () => {
+    const collection = new StoreCollection<Data>();
+
+    const update = () => collection.update({ where: () => false, data: {} });
+
+    expect(update).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: No entry found in the collection for the given strict query.]`,
+    );
+    expect(collection.all()).toStrictEqual([]);
+  });
+
+  test("update no entry when none matches and strict is false", () => {
+    const collection = new StoreCollection<Data>();
+
+    const updated = collection.update({
+      strict: false,
+      where: () => false,
+      data: { a: 2 },
+    });
+
+    expect(updated).toBe(null);
+    expect(collection.all()).toStrictEqual([]);
+  });
+});
+
+suite("StoreCollection.prototype.delete", () => {
+  test("deletes the first entry that matches the query", () => {
+    const collection = new StoreCollection<Data>();
+    collection.insert({ a: 1, b: 0 });
+    collection.insert({ a: 1, b: 1 });
+    collection.insert({ a: 0, b: 1 });
+
+    const entry = collection.delete({ where: (e) => e.b === 1 });
+
+    expect(entry).toStrictEqual({ a: 1, b: 1 });
+    expect(collection.all()).toStrictEqual([
+      { a: 1, b: 0 },
+      { a: 0, b: 1 },
+    ]);
+  });
+
+  test("throws an error when no entry matches the given query", () => {
+    const collection = new StoreCollection<Data>();
+
+    const search = () => collection.delete({ where: () => false });
+
+    expect(search).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: No entry found in the collection for the given strict query.]`,
+    );
+  });
+
+  test("deletes no entry when none matches and strict is false", () => {
+    const collection = new StoreCollection<Data>();
+    collection.insert({ a: 1, b: 0 });
+    collection.insert({ a: 1, b: 1 });
+    collection.insert({ a: 0, b: 1 });
+
+    const entry = collection.delete({ strict: false, where: () => false });
+
+    expect(entry).toBe(null);
+    expect(collection.all()).toStrictEqual([
+      { a: 1, b: 0 },
+      { a: 1, b: 1 },
+      { a: 0, b: 1 },
+    ]);
+  });
+});

--- a/src/store-collection.test.ts
+++ b/src/store-collection.test.ts
@@ -90,3 +90,68 @@ suite("StoreCollection.prototype.insert", () => {
     expect(collection.latest()).toStrictEqual(entry);
   });
 });
+
+suite("StoreCollection.prototype.find", () => {
+  test("returns the first entry that matches the query", () => {
+    const collection = new StoreCollection<Data>();
+    collection.insert({ a: 1, b: 0 });
+    collection.insert({ a: 1, b: 1 });
+    collection.insert({ a: 0, b: 1 });
+
+    const entry = collection.find({ where: (e) => e.b === 1 });
+
+    expect(entry).toStrictEqual({ a: 1, b: 1 });
+  });
+
+  test("throws an error when no entry matches the given query", () => {
+    const collection = new StoreCollection<Data>();
+
+    const search = () => collection.find({ where: () => false });
+
+    expect(search).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: No entry found in the collection for the given strict query.]`,
+    );
+  });
+
+  test("returns null when no entry matches the query and strict is false", () => {
+    const collection = new StoreCollection<Data>();
+
+    const entry = collection.find({ strict: false, where: () => false });
+
+    expect(entry).toBe(null);
+  });
+});
+
+suite("StoreCollection.prototype.findMany", () => {
+  test("returns all entries that match the query", () => {
+    const collection = new StoreCollection<Data>();
+    collection.insert({ a: 1, b: 0 });
+    collection.insert({ a: 1, b: 1 });
+    collection.insert({ a: 0, b: 1 });
+
+    const entries = collection.findMany({ where: (e) => e.a === 1 });
+
+    expect(entries).toStrictEqual([
+      { a: 1, b: 0 },
+      { a: 1, b: 1 },
+    ]);
+  });
+
+  test("returns an empty array when no entries match the query", () => {
+    const collection = new StoreCollection<Data>();
+    collection.insert({ a: 1, b: 0 });
+    collection.insert({ a: 0, b: 1 });
+
+    const entries = collection.findMany({ where: () => false });
+
+    expect(entries).toStrictEqual([]);
+  });
+
+  test("returns an empty array when the collection is empty", () => {
+    const collection = new StoreCollection<Data>();
+
+    const entries = collection.findMany({ where: () => true });
+
+    expect(entries).toStrictEqual([]);
+  });
+});

--- a/src/store-collection.ts
+++ b/src/store-collection.ts
@@ -1,4 +1,10 @@
-import { assertStrict, type Query, type StrictQuery } from "./query.js";
+import {
+  applyUpdateQuery,
+  assertStrict,
+  type Query,
+  type StrictQuery,
+  type UpdateQuery,
+} from "./query.js";
 
 export class StoreCollection<Shape> {
   #entries: Shape[];
@@ -39,5 +45,28 @@ export class StoreCollection<Shape> {
 
   findMany(query: Query<Shape>): Shape[] {
     return this.#entries.filter(query.where);
+  }
+
+  update(query: UpdateQuery<Shape, true>): Shape;
+  update(query: UpdateQuery<Shape, false>): Shape | null;
+  update(query: UpdateQuery<Shape, boolean>): Shape | null {
+    const index = this.#entries.findIndex(query.where);
+    const entry = assertStrict(query, this.#entries[index]);
+    if (!entry) return null;
+
+    const updated = applyUpdateQuery(entry, query);
+    this.#entries[index] = updated;
+    return updated;
+  }
+
+  delete(query: StrictQuery<Shape, true>): Shape;
+  delete(query: StrictQuery<Shape, false>): Shape | null;
+  delete(query: StrictQuery<Shape, boolean>): Shape | null {
+    const index = this.#entries.findIndex(query.where);
+    const entry = assertStrict(query, this.#entries[index]);
+    if (!entry) return null;
+
+    this.#entries.splice(index, 1);
+    return entry;
   }
 }

--- a/src/store-collection.ts
+++ b/src/store-collection.ts
@@ -1,3 +1,5 @@
+import { assertStrict, type Query, type StrictQuery } from "./query.js";
+
 export class StoreCollection<Shape> {
   #entries: Shape[];
 
@@ -26,5 +28,16 @@ export class StoreCollection<Shape> {
   insert(entry: Shape): Shape {
     this.#entries.push(entry);
     return entry;
+  }
+
+  find(query: StrictQuery<Shape, true>): Shape;
+  find(query: StrictQuery<Shape, false>): Shape | null;
+  find(query: StrictQuery<Shape, boolean>): Shape | null {
+    const entry = this.#entries.find(query.where);
+    return assertStrict(query, entry);
+  }
+
+  findMany(query: Query<Shape>): Shape[] {
+    return this.#entries.filter(query.where);
   }
 }


### PR DESCRIPTION
This PR adds the following methods to collections. Except for `findMany`, all support running in strict and non-strict mode.

- `find`
- `findMany`
- `update`
- `delete`