### PR TITLE
 feat: output declaration maps for proper jump-to-source support

### DIFF
--- a/.changeset/three-ads-beg.md
+++ b/.changeset/three-ads-beg.md
@@ -1,0 +1,5 @@
+---
+"test-data-factory": minor
+---
+
+Added declaration maps to the build output. Together with packaged source files, this enables proper "Go To Definition" support in editors — jumping directly to the TypeScript source file instead of the declaration file.

--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
   "repository": "github:christoph-fricke/test-data-factory",
   "files": [
     "dist",
-    "CHANGELOG.md",
+    "exports",
+    "src",
+    "!src/**/*.test.ts",
     "README.md",
     "LICENSE"
   ],
   "exports": {
     ".": {
       "types": "./dist/exports/main.d.ts",
-      "import": "./dist/exports/main.js"
+      "default": "./dist/exports/main.js"
     }
   },
   "scripts": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,
-    "sourceMap": true,
-    "inlineSources": true
+    "declarationMap": true,
+    "sourceMap": true
   },
   "include": ["exports", "src"],
   "exclude": ["**/*.test.*"]


### PR DESCRIPTION
This enables proper "Go To Definition" support in editors — jumping directly to the TypeScript source file instead of the declaration file.