### PR TITLE
ci: prepare trusted publishing via OIDC

### DIFF
--- a/.changeset/open-onions-tickle.md
+++ b/.changeset/open-onions-tickle.md
@@ -1,0 +1,5 @@
+---
+"test-data-factory": minor
+---
+
+Changed the publishing flow to use [trusted publishing](https://docs.npmjs.com/trusted-publishers) via OIDC instead of a token-based approach.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  id-token: write # to publish with provenance
-  contents: write #  to create release (changesets/action)
-  issues: write # to post issue comments (changesets/action)
-  pull-requests: write #  to create pull request (changesets/action)
+  id-token: write # for trusted publishing via OIDC
+  contents: write # for creating releases (changesets/action)
+  issues: write # for posting issue comments (changesets/action)
+  pull-requests: write # for creating pull requests (changesets/action)
 
 jobs:
   release:
@@ -37,6 +37,4 @@ jobs:
           commit: "ci: release package"
           title: "ci: release package"
         env:
-          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR enables a newer, more secure publishing flow via OpenID Connect. See: https://docs.npmjs.com/trusted-publishers