### PR TITLE
feat: expose abstract-store and shape-for helper type

### DIFF
--- a/.changeset/blue-tires-serve.md
+++ b/.changeset/blue-tires-serve.md
@@ -1,0 +1,5 @@
+---
+"test-data-factory": minor
+---
+
+Added the abstract `AbstractStore` class to the package exports.

--- a/.changeset/silly-balloons-lie.md
+++ b/.changeset/silly-balloons-lie.md
@@ -1,0 +1,5 @@
+---
+"test-data-factory": minor
+---
+
+Exposed the `ShapeFor<Factory>` helper type to the package exports. It returns the data shape of a given factory.

--- a/exports/main.ts
+++ b/exports/main.ts
@@ -1,4 +1,5 @@
+export { AbstractStore } from "../src/abstract-store.ts";
 export { defineFactory, type ConstructFn } from "../src/factory-shorthand.ts";
-export { Factory, type FactoryContext } from "../src/factory.ts";
+export { Factory, type FactoryContext, type ShapeFor } from "../src/factory.ts";
 export type { Params } from "../src/params.ts";
 export { Store } from "../src/store.ts";

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -7,7 +7,7 @@ import {
   type ParamsOrFunc,
 } from "./params.ts";
 
-type ShapeFor<F> = F extends Factory<infer S> ? S : never;
+export type ShapeFor<F> = F extends Factory<infer S> ? S : never;
 interface FactoryClass<Factory, Shape> {
   new (state: SharedState, params?: Params<Shape>): Factory;
 }


### PR DESCRIPTION
With exposing the `AbstractStore` and `ShapeFor` helper type, it becomes easier to extend the functionality of factories. 